### PR TITLE
Add HTTP header setting

### DIFF
--- a/examples/basic/src/templates/index.rs
+++ b/examples/basic/src/templates/index.rs
@@ -1,4 +1,4 @@
-use perseus::{GenericNode, StringResultWithCause, Template};
+use perseus::{GenericNode, StringResultWithCause, Template, http::header::{HeaderMap, HeaderName}};
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 use sycamore::prelude::{component, template, Template as SycamoreTemplate};
@@ -21,6 +21,7 @@ pub fn get_template<G: GenericNode>() -> Template<G> {
         .build_state_fn(Rc::new(get_build_props))
         .template(template_fn())
         .head(head_fn())
+        .set_headers_fn(set_headers_fn())
 }
 
 pub async fn get_build_props(_path: String) -> StringResultWithCause<String> {
@@ -45,5 +46,13 @@ pub fn head_fn() -> perseus::template::HeadFn {
         template! {
             title { "Index Page | Perseus Example – Basic" }
         }
+    })
+}
+
+pub fn set_headers_fn() -> perseus::template::SetHeadersFn {
+    Rc::new(|_| {
+        let mut map = HeaderMap::new();
+        map.insert(HeaderName::from_lowercase(b"x-test").unwrap(), "custom value".parse().unwrap());
+        map
     })
 }

--- a/examples/basic/src/templates/index.rs
+++ b/examples/basic/src/templates/index.rs
@@ -1,4 +1,7 @@
-use perseus::{GenericNode, StringResultWithCause, Template, http::header::{HeaderMap, HeaderName}};
+use perseus::{
+    http::header::{HeaderMap, HeaderName},
+    GenericNode, StringResultWithCause, Template,
+};
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 use sycamore::prelude::{component, template, Template as SycamoreTemplate};
@@ -52,7 +55,10 @@ pub fn head_fn() -> perseus::template::HeadFn {
 pub fn set_headers_fn() -> perseus::template::SetHeadersFn {
     Rc::new(|_| {
         let mut map = HeaderMap::new();
-        map.insert(HeaderName::from_lowercase(b"x-test").unwrap(), "custom value".parse().unwrap());
+        map.insert(
+            HeaderName::from_lowercase(b"x-test").unwrap(),
+            "custom value".parse().unwrap(),
+        );
         map
     })
 }

--- a/examples/i18n/tests/main.rs
+++ b/examples/i18n/tests/main.rs
@@ -8,7 +8,6 @@ async fn main(c: &mut Client) -> Result<(), fantoccini::error::CmdError> {
     let url = c.current_url().await?;
     // We only test for one locale here because changing the browser's preferred languages is very hard, we do unit testing on the locale detection system instead
     assert!(url.as_ref().starts_with("http://localhost:8080/en-US"));
-    // TODO test locale detection (unit testing)
     // This tests translations, variable interpolation, and multiple aspects of Sycamore all at once
     let text = c.find(Locator::Css("p")).await?.text().await?;
     assert_eq!(text, "Hello, \u{2068}User\u{2069}!"); // Ask Fluent about these characters

--- a/packages/perseus-actix-web/src/initial_load.rs
+++ b/packages/perseus-actix-web/src/initial_load.rs
@@ -125,9 +125,14 @@ pub async fn initial_load<C: ConfigManager, T: TranslationsManager>(
 
             let final_html = interpolate_page_data(&html_shell, &page_data, &opts.root_id);
 
-            HttpResponse::Ok()
-                .content_type("text/html")
-                .body(final_html)
+            let mut http_res = HttpResponse::Ok();
+            http_res.content_type("text/html");
+            // Generate and add HTTP headers
+            for (key, val) in template.get_headers(page_data.state.clone()) {
+                http_res.set_header(key.unwrap(), val);
+            }
+
+            http_res.body(final_html)
         }
         // For locale detection, we don't know the user's locale, so there's not much we can do except send down the app shell, which will do the rest and fetch from `.perseus/page/...`
         RouteVerdict::LocaleDetection(_) => {

--- a/packages/perseus-actix-web/src/page_data.rs
+++ b/packages/perseus-actix-web/src/page_data.rs
@@ -63,7 +63,7 @@ pub async fn page_data<C: ConfigManager, T: TranslationsManager>(
                 }
 
                 http_res.body(serde_json::to_string(&page_data).unwrap())
-            },
+            }
             // We parse the error to return an appropriate status code
             Err(err) => {
                 HttpResponse::build(StatusCode::from_u16(err_to_status_code(&err)).unwrap())

--- a/packages/perseus-actix-web/src/page_data.rs
+++ b/packages/perseus-actix-web/src/page_data.rs
@@ -54,7 +54,16 @@ pub async fn page_data<C: ConfigManager, T: TranslationsManager>(
         )
         .await;
         match page_data {
-            Ok(page_data) => HttpResponse::Ok().body(serde_json::to_string(&page_data).unwrap()),
+            Ok(page_data) => {
+                let mut http_res = HttpResponse::Ok();
+                http_res.content_type("text/html");
+                // Generate and add HTTP headers
+                for (key, val) in template.get_headers(page_data.state.clone()) {
+                    http_res.set_header(key.unwrap(), val);
+                }
+
+                http_res.body(serde_json::to_string(&page_data).unwrap())
+            },
             // We parse the error to return an appropriate status code
             Err(err) => {
                 HttpResponse::build(StatusCode::from_u16(err_to_status_code(&err)).unwrap())

--- a/packages/perseus/src/default_headers.rs
+++ b/packages/perseus/src/default_headers.rs
@@ -1,7 +1,9 @@
-use http::header::HeaderMap;
+use http::header::{self, HeaderMap};
 
 /// Creates the default headers used in Perseus. This is the default value for `set_headers` on every `Template<G>`
 // TODO
 pub(crate) fn default_headers() -> HeaderMap {
-    HeaderMap::new()
+    let mut map = HeaderMap::new();
+    map.insert(header::CACHE_CONTROL, "max-age=300".parse().unwrap());
+    map
 }

--- a/packages/perseus/src/default_headers.rs
+++ b/packages/perseus/src/default_headers.rs
@@ -1,0 +1,7 @@
+use http::header::HeaderMap;
+
+/// Creates the default headers used in Perseus. This is the default value for `set_headers` on every `Template<G>`
+// TODO
+pub(crate) fn default_headers() -> HeaderMap {
+    HeaderMap::new()
+}

--- a/packages/perseus/src/lib.rs
+++ b/packages/perseus/src/lib.rs
@@ -41,6 +41,7 @@ mod client_translations_manager;
 /// Utilities for creating custom config managers, as well as the default `FsConfigManager`.
 pub mod config_manager;
 mod decode_time_str;
+mod default_headers;
 /// Utilities regarding the formation of error pages for HTTP status codes, like a `404 Not Found` page.
 pub mod error_pages;
 pub mod errors;
@@ -65,7 +66,6 @@ mod test;
 pub mod translations_manager;
 /// Utilities regarding translators, including the default `FluentTranslator`.
 pub mod translator;
-mod default_headers;
 
 pub use http;
 pub use http::Request as HttpRequest;

--- a/packages/perseus/src/lib.rs
+++ b/packages/perseus/src/lib.rs
@@ -65,6 +65,7 @@ mod test;
 pub mod translations_manager;
 /// Utilities regarding translators, including the default `FluentTranslator`.
 pub mod translator;
+mod default_headers;
 
 pub use http;
 pub use http::Request as HttpRequest;

--- a/packages/perseus/src/template.rs
+++ b/packages/perseus/src/template.rs
@@ -1,17 +1,17 @@
 // This file contains logic to define how templates are rendered
 
+use crate::default_headers::default_headers;
 use crate::errors::*;
 use crate::Request;
 use crate::SsrNode;
 use crate::Translator;
-use crate::default_headers::default_headers;
 use futures::Future;
+use http::header::HeaderMap;
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::rc::Rc;
 use sycamore::context::{ContextProvider, ContextProviderProps};
 use sycamore::prelude::{template, GenericNode, Template as SycamoreTemplate};
-use http::header::HeaderMap;
 
 /// Represents all the different states that can be generated for a single template, allowing amalgamation logic to be run with the knowledge
 /// of what did what (rather than blindly working on a vector).


### PR DESCRIPTION
This allows a template to set HTTP headers for responses in which it's successfully returned, with an aim at allowing sensible and customizable cache control for revalidating pages.