### PR TITLE
Add `--release` to CLI

### DIFF
--- a/packages/perseus-actix-web/src/initial_load.rs
+++ b/packages/perseus-actix-web/src/initial_load.rs
@@ -137,7 +137,7 @@ pub async fn initial_load<C: ConfigManager, T: TranslationsManager>(
             let mut http_res = HttpResponse::Ok();
             http_res.content_type("text/html");
             // Generate and add HTTP headers
-            for (key, val) in template.get_headers(page_data.state.clone()) {
+            for (key, val) in template.get_headers(page_data.state) {
                 http_res.set_header(key.unwrap(), val);
             }
 

--- a/packages/perseus-cli/src/bin/main.rs
+++ b/packages/perseus-cli/src/bin/main.rs
@@ -113,7 +113,7 @@ fn core(dir: PathBuf) -> Result<i32, Error> {
                 // We don't delete `render_conf.json` because it's literally impossible for that to be the source of a problem right now
                 delete_artifacts(dir.clone(), "static")?;
                 delete_artifacts(dir.clone(), "pkg")?;
-                delete_artifacts(dir.clone(), "exported")?;
+                delete_artifacts(dir, "exported")?;
             } else {
                 // This command deletes the `.perseus/` directory completely, which musn't happen if the user has ejected
                 if has_ejected(dir.clone()) && !clean_opts.force {

--- a/packages/perseus-cli/src/parse.rs
+++ b/packages/perseus-cli/src/parse.rs
@@ -32,14 +32,14 @@ pub enum Subcommand {
 pub struct BuildOpts {
     /// Build for production
     #[clap(long)]
-    release: bool,
+    pub release: bool,
 }
 /// Exports your app to purely static files
 #[derive(Clap)]
 pub struct ExportOpts {
     /// Export for production
     #[clap(long)]
-    release: bool,
+    pub release: bool,
 }
 /// Serves your app (set the `$HOST` and `$PORT` environment variables to change the location it's served at)
 #[derive(Clap)]
@@ -52,7 +52,7 @@ pub struct ServeOpts {
     pub no_build: bool,
     /// Build and serve for production
     #[clap(long)]
-    release: bool,
+    pub release: bool,
 }
 /// Removes `.perseus/` entirely for updates or to fix corruptions
 #[derive(Clap)]

--- a/packages/perseus/src/translations_manager.rs
+++ b/packages/perseus/src/translations_manager.rs
@@ -125,13 +125,11 @@ impl TranslationsManager for FsTranslationsManager {
                     }
                 })?,
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    return Err(TranslationsManagerError::NotFound {
-                        locale: locale.clone(),
-                    })
+                    return Err(TranslationsManagerError::NotFound { locale })
                 }
                 Err(err) => {
                     return Err(TranslationsManagerError::ReadFailed {
-                        locale: locale.clone(),
+                        locale,
                         source: err.into(),
                     })
                 }


### PR DESCRIPTION
This adds a new flag to the `build`, `serve`, and `export` commands in the CLI that will build for production, making it now possible to deploy Perseus apps in production (technically, it's still not recommended though).

Closes #30.