### PR TITLE
Add -r flag to entr commands in docs

### DIFF
--- a/docs/0.1.x/en-US/cli.md
+++ b/docs/0.1.x/en-US/cli.md
@@ -94,7 +94,7 @@ If you want to serve pre-built files (which you'll have to generate with `perseu
 All these commands act statically, they don't watch your code for any changes. This feature will be added _very_ soon to the CLI, but until it is, we advise you to use a tool like [`entr`](https://github.com/eradman/entr), which you can make work with Perseus like so (on Linux):
 
 ```
-find . -not -path "./.perseus/*" -not -path "./target/*" | entr -s "perseus serve"
+find . -not -path "./.perseus/*" -not -path "./target/*" | entr -rs "perseus serve"
 ```
 
 This just lists all files except those in `.perseus/` and `target/` and runs `perseus serve` on any changes. You should exclude anything else as necessary.

--- a/docs/0.2.x/en-US/cli.md
+++ b/docs/0.2.x/en-US/cli.md
@@ -31,5 +31,5 @@ Right now, the Perseus CLI doesn't support watching files for changes and rebuil
 Here's an example of watching files with `entr`:
 
 ```
-find . -not -path "./.perseus/*" -not -path "./target/*" | entr -s "perseus serve"
+find . -not -path "./.perseus/*" -not -path "./target/*" | entr -rs "perseus serve"
 ```

--- a/docs/0.3.x/en-US/cli.md
+++ b/docs/0.3.x/en-US/cli.md
@@ -43,5 +43,5 @@ Right now, the Perseus CLI doesn't support watching files for changes and rebuil
 Here's an example of watching files with `entr`:
 
 ```
-find . -not -path "./.perseus/*" -not -path "./target/*" | entr -s "perseus serve"
+find . -not -path "./.perseus/*" -not -path "./target/*" | entr -rs "perseus serve"
 ```

--- a/docs/next/en-US/cli.md
+++ b/docs/next/en-US/cli.md
@@ -43,5 +43,5 @@ Right now, the Perseus CLI doesn't support watching files for changes and rebuil
 Here's an example of watching files with `entr`:
 
 ```
-find . -not -path "./.perseus/*" -not -path "./target/*" | entr -s "perseus serve"
+find . -not -path "./.perseus/*" -not -path "./target/*" | entr -rs "perseus serve"
 ```


### PR DESCRIPTION
Otherwise, it doesn't reload, since `perseus serve` is long-lived.