### PR TITLE
Add website node modules install step to `bonnie setup`

### DIFF
--- a/bonnie.toml
+++ b/bonnie.toml
@@ -9,6 +9,7 @@ setup.cmd = [
     "mkdir -p examples/basic/.perseus/dist/exported",
     "bonnie copy-subcrates",
     "cargo build",
+    "npm i --prefix ./website",
     "echo \"\n\nThe Perseus repository is ready for local development! Type 'bonnie help' to see the available commands you can run here. Also, please ensure that you have 'npx' available and that you've installed 'tailwindcss', `concurrently`, `serve` and 'browser-sync' ('npm i -g tailwindcss concurrently serve browser-sync') if you'll be working with the website or running `bonnie dev export-serve ...`.\""
 ]
 setup.desc = "sets everything up for local development"


### PR DESCRIPTION
Without the `npm i --prefix ./website` step prior to `bonnie site run` an error as bellow is thrown and styles on the website are all out of place.

```sh
(node:17003) UnhandledPromiseRejectionWarning: Error: Cannot find module 'tailwindcss/defaultTheme'
Require stack:
- /home/user/perseus/website/tailwind.config.js
- /home/user/emsdk/node/14.15.5_64bit/lib/node_modules/tailwindcss/lib/cli.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/home/user/perseus/website/tailwind.config.js:1:22)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:17003) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:17003) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```