### PR TITLE
Refactor html_shell.rs to improve readability

### DIFF
--- a/examples/basic/.perseus/builder/src/bin/export_error_page.rs
+++ b/examples/basic/.perseus/builder/src/bin/export_error_page.rs
@@ -2,7 +2,7 @@ use fmterr::fmt_err;
 use perseus::{
     internal::{
         get_path_prefix_server,
-        serve::{build_error_page, get_render_cfg, prep_html_shell},
+        serve::{build_error_page, get_render_cfg, HtmlShell},
     },
     PluginAction, SsrNode,
 };
@@ -38,7 +38,7 @@ async fn real_main() -> i32 {
             return 1;
         }
     };
-    let html = prep_html_shell(html, &render_cfg, &get_path_prefix_server());
+    let html_shell = HtmlShell::new(html, &render_cfg, &get_path_prefix_server());
     // Get the error code to build from the arguments to this executable
     let args = env::args().collect::<Vec<String>>();
     let err_code_to_build_for = match args.get(1) {
@@ -69,7 +69,7 @@ async fn real_main() -> i32 {
         "",
         None,
         &error_pages,
-        &html,
+        &html_shell,
         &root_id,
     );
 

--- a/packages/perseus-actix-web/src/configurer.rs
+++ b/packages/perseus-actix-web/src/configurer.rs
@@ -7,7 +7,7 @@ use perseus::{
     internal::{
         get_path_prefix_server,
         i18n::TranslationsManager,
-        serve::{get_render_cfg, prep_html_shell, ServerOptions, ServerProps},
+        serve::{get_render_cfg, HtmlShell, ServerOptions, ServerProps},
     },
     stores::MutableStore,
 };
@@ -50,7 +50,7 @@ pub async fn configurer<M: MutableStore + 'static, T: TranslationsManager + 'sta
     // Get the index file and inject the render configuration into ahead of time
     // Anything done here will affect any status code and all loads
     let index_file = fs::read_to_string(&opts.index).expect("Couldn't get HTML index file!");
-    let index_with_render_cfg = prep_html_shell(index_file, &render_cfg, &get_path_prefix_server());
+    let index_with_render_cfg = HtmlShell::new(index_file, &render_cfg, &get_path_prefix_server());
 
     move |cfg: &mut web::ServiceConfig| {
         cfg

--- a/packages/perseus-actix-web/src/initial_load.rs
+++ b/packages/perseus-actix-web/src/initial_load.rs
@@ -8,8 +8,8 @@ use perseus::{
         i18n::{TranslationsManager, Translator},
         router::{match_route_atomic, RouteInfoAtomic, RouteVerdictAtomic},
         serve::{
-            build_error_page, get_path_slice, interpolate_locale_redirection_fallback,
-            interpolate_page_data, render::get_page_for_template, ServerOptions,
+            build_error_page, get_path_slice, render::get_page_for_template, HtmlShell,
+            ServerOptions,
         },
     },
     stores::{ImmutableStore, MutableStore},
@@ -40,7 +40,7 @@ fn return_error_page(
 pub async fn initial_load<M: MutableStore, T: TranslationsManager>(
     req: HttpRequest,
     opts: web::Data<Rc<ServerOptions>>,
-    html_shell: web::Data<String>,
+    html_shell: web::Data<HtmlShell<'_>>,
     render_cfg: web::Data<HashMap<String, String>>,
     immutable_store: web::Data<ImmutableStore>,
     mutable_store: web::Data<M>,
@@ -58,7 +58,7 @@ pub async fn initial_load<M: MutableStore, T: TranslationsManager>(
             err,
             None,
             error_pages,
-            html_shell.get_ref(),
+            &html_shell.get_ref().to_string(),
             &opts.root_id,
         );
     };
@@ -102,7 +102,11 @@ pub async fn initial_load<M: MutableStore, T: TranslationsManager>(
                 }
             };
 
-            let final_html = interpolate_page_data(&html_shell, &page_data, &opts.root_id);
+            let final_html = html_shell
+                .get_ref()
+                .clone()
+                .page_data(&page_data, &opts.root_id)
+                .to_string();
 
             let mut http_res = HttpResponse::Ok();
             http_res.content_type("text/html");
@@ -118,17 +122,20 @@ pub async fn initial_load<M: MutableStore, T: TranslationsManager>(
             // We use a `302 Found` status code to indicate a redirect
             // We 'should' generate a `Location` field for the redirect, but it's not RFC-mandated, so we can use the app shell
             HttpResponse::Found().content_type("text/html").body(
-                interpolate_locale_redirection_fallback(
-                    html_shell.get_ref(),
-                    // We'll redirect the user to the default locale
-                    &format!(
-                        "{}/{}/{}",
-                        get_path_prefix_server(),
-                        opts.locales.default,
-                        path
-                    ),
-                    &opts.root_id,
-                ),
+                html_shell
+                    .get_ref()
+                    .clone()
+                    .locale_redirection_fallback(
+                        // We'll redirect the user to the default locale
+                        &format!(
+                            "{}/{}/{}",
+                            get_path_prefix_server(),
+                            opts.locales.default,
+                            path
+                        ),
+                        &opts.root_id,
+                    )
+                    .to_string(),
             )
         }
         RouteVerdictAtomic::NotFound => html_err(404, "page not found"),

--- a/packages/perseus-actix-web/src/initial_load.rs
+++ b/packages/perseus-actix-web/src/initial_load.rs
@@ -26,10 +26,18 @@ fn return_error_page(
     err: &str,
     translator: Option<Rc<Translator>>,
     error_pages: &ErrorPages<SsrNode>,
-    html: &str,
+    html_shell: &HtmlShell,
     root_id: &str,
 ) -> HttpResponse {
-    let html = build_error_page(url, status, err, translator, error_pages, html, root_id);
+    let html = build_error_page(
+        url,
+        status,
+        err,
+        translator,
+        error_pages,
+        html_shell,
+        root_id,
+    );
     HttpResponse::build(StatusCode::from_u16(*status).unwrap())
         .content_type("text/html")
         .body(html)
@@ -58,7 +66,7 @@ pub async fn initial_load<M: MutableStore, T: TranslationsManager>(
             err,
             None,
             error_pages,
-            &html_shell.get_ref().to_string(),
+            html_shell.get_ref(),
             &opts.root_id,
         );
     };

--- a/packages/perseus-warp/src/initial_load.rs
+++ b/packages/perseus-warp/src/initial_load.rs
@@ -24,10 +24,18 @@ fn return_error_page(
     err: &str,
     translator: Option<Rc<Translator>>,
     error_pages: &ErrorPages<SsrNode>,
-    html: &str,
+    html_shell: &HtmlShell,
     root_id: &str,
 ) -> Response<String> {
-    let html = build_error_page(url, status, err, translator, error_pages, html, root_id);
+    let html = build_error_page(
+        url,
+        status,
+        err,
+        translator,
+        error_pages,
+        html_shell,
+        root_id,
+    );
     Response::builder().status(*status).body(html).unwrap()
 }
 
@@ -56,7 +64,7 @@ pub async fn initial_load_handler<M: MutableStore, T: TranslationsManager>(
             err,
             None,
             error_pages,
-            &html_shell.as_ref().to_string(),
+            html_shell.as_ref(),
             &opts.root_id,
         );
     };

--- a/packages/perseus-warp/src/perseus_routes.rs
+++ b/packages/perseus-warp/src/perseus_routes.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use perseus::internal::serve::{get_render_cfg, ServerProps};
 use perseus::{
-    internal::{get_path_prefix_server, i18n::TranslationsManager, serve::prep_html_shell},
+    internal::{get_path_prefix_server, i18n::TranslationsManager, serve::HtmlShell},
     stores::MutableStore,
 };
 use std::{fs, sync::Arc};
@@ -28,7 +28,7 @@ pub async fn perseus_routes<M: MutableStore + 'static, T: TranslationsManager + 
         .await
         .expect("Couldn't get render configuration!");
     let index_file = fs::read_to_string(&opts.index).expect("Couldn't get HTML index file!");
-    let index_with_render_cfg = prep_html_shell(index_file, &render_cfg, &get_path_prefix_server());
+    let index_with_render_cfg = HtmlShell::new(index_file, &render_cfg, &get_path_prefix_server());
 
     // Handle static files
     let js_bundle = warp::path!(".perseus" / "bundle.js")

--- a/packages/perseus/src/html_shell.rs
+++ b/packages/perseus/src/html_shell.rs
@@ -2,56 +2,87 @@ use crate::page_data::PageData;
 use std::collections::HashMap;
 use std::env;
 
-/// Initializes the HTML shell by interpolating necessary scripts into it, as well as by adding the render configuration.
-pub fn prep_html_shell(
-    html_shell: String,
-    render_cfg: &HashMap<String, String>,
-    path_prefix: &str,
-) -> String {
-    // Define the script that will load the Wasm bundle (inlined to avoid unnecessary extra requests)
-    let load_script = format!(
-        r#"<script type="module">
-    import init, {{ run }} from "{path_prefix}/.perseus/bundle.js";
-    async function main() {{
-        await init("{path_prefix}/.perseus/bundle.wasm");
-        run();
-    }}
-    main();
-</script>"#,
-        path_prefix = path_prefix
-    );
-    // We inject a script that defines the render config as a global variable, which we put just before the close of the head
-    // We also inject a delimiter comment that will be used to wall off the constant document head from the interpolated document head
-    // We also inject the above script to load the Wasm bundle (avoids extra trips)
-    // We also inject a global variable to identify that we're testing if we are (picked up by app shell to trigger helper DOM events)
-    // We also inject a `<base>` tag with the base path of the app, which allows us to serve at relative paths just from an environment variable
-    let prepared = html_shell.replace(
-        "</head>",
-        // It's safe to assume that something we just deserialized will serialize again in this case
-        &format!(
-            "<script>window.__PERSEUS_RENDER_CFG = '{}';{testing_var}</script>\n{}\n<!--PERSEUS_INTERPOLATED_HEAD_BEGINS-->\n</head>",
-            serde_json::to_string(&render_cfg).unwrap(),
-            load_script,
-            testing_var=if env::var("PERSEUS_TESTING").is_ok() {
-                "window.__PERSEUS_TESTING = true;"
-            } else {
-                ""
-            }
-        ),
-    );
-    // Add in the `<base>` element at the very top so that it applies to everything in the HTML shell
-    // Otherwise any stylesheets loaded before it won't work properly
-    let prepared_with_base = prepared.replace(
-        "<head>",
-        &format!(
-            "<head>\n<base href=\"{path_prefix}\" />",
-            // We add a trailing `/` to the base URL (https://stackoverflow.com/a/26043021)
-            // Note that it's already had any pre-existing ones stripped away
-            path_prefix = format!("{}/", path_prefix)
-        ),
-    );
+const INTERPOLATED_HEAD_MARKER: &str = "<!-- PERSEUS_INTERPOLATED_HEAD_BEGINS -->";
 
-    prepared_with_base
+struct HtmlShell {
+    inner: String,
+}
+
+impl HtmlShell {
+    /// Initializes the HTML shell by interpolating necessary scripts into it, as well as by adding the render configuration.
+    fn new(shell: &str, render_cfg: &HashMap<String, String>, path_prefix: &str) -> Self {
+        let set_testing_flag = if env::var("PERSEUS_TESTING").is_ok() {
+            "window.__PERSEUS_TESTING = true;"
+        } else {
+            ""
+        };
+
+        // Here is the list of things that we are adding *right after* the beginning of the <head> tag:
+        //
+        // - Render config as a global variable.
+        //
+        // - Global variable to identify whether we are testing (picked up by app shell to trigger helper DOM events).
+        //
+        // - A `<base>` tag with the base path of the app, which allows us to serve at relative paths just from an environment variable.
+        //
+        //      This one has to be at the very top of the <head> element so that it applies to everything in the HTML shell.
+        //      Otherwise any stylesheets loaded before it won't work properly.
+        //
+        //      Also add a trailing `/` to the path_prefix (https://stackoverflow.com/a/26043021);
+        //      note that it's already had any pre-existing ones stripped away.
+        //
+        let script = format!(
+            r#"
+        <base href="{path_prefix}/" />
+        <script type="module">
+            window.__PERSEUS_RENDER_CFG = '{render_config}';
+            {set_testing_flag}
+    
+            import init, {{ run }} from "{path_prefix}/.perseus/bundle.js";
+            async function main() {{
+                await init("{path_prefix}/.perseus/bundle.wasm");
+                run();
+            }}
+            main();
+        </script>
+        "#,
+            path_prefix = path_prefix,
+            render_config = serde_json::to_string(render_cfg).unwrap(),
+            set_testing_flag = set_testing_flag,
+        );
+
+        let shell = shell.replace("<head>", &format!("<head>{}", script));
+
+        // Append a delimiter comment that will be used to wall off the constant document head from the interpolated document head.
+        let shell = shell.replace("</head>", &format!("{}</head>", INTERPOLATED_HEAD_MARKER));
+        Self { inner: shell }
+    }
+
+    fn interpolate_page_data(self, page_data: &PageData, root_id: &str) {
+        let html_with_head = self.inner.replace(
+            INTERPOLATED_HEAD_MARKER,
+            &format!("{0}{1}", INTERPOLATED_HEAD_MARKER, &page_data.head),
+        );
+
+        // Interpolate a global variable of the state so the app shell doesn't have to make any more trips
+        // The app shell will unset this after usage so it doesn't contaminate later non-initial loads
+        // Error pages (above) will set this to `error`
+        let state_var = format!("<script>window.__PERSEUS_INITIAL_STATE = `{}`;</script>", {
+            if let Some(state) = &page_data.state {
+                state
+                    // We escape any backslashes to prevent their interfering with JSON delimiters
+                    .replace(r#"\"#, r#"\\"#)
+                    // We escape any backticks, which would interfere with JS's raw strings system
+                    .replace(r#"`"#, r#"\`"#)
+                    // We escape any interpolations into JS's raw string system
+                    .replace(r#"${"#, r#"\${"#)
+            } else {
+                "None".to_string()
+            }
+        });
+
+        let html_with_state = html_with_head.replace("</head>", &format!("{}\n</head>", state_var));
+    }
 }
 
 /// Interpolates content, metadata, and state into the HTML shell, ready to be sent to the user for initial loads. This should be passed
@@ -159,4 +190,30 @@ pub fn interpolate_locale_redirection_fallback(
     // Now interpolate that HTML into the HTML shell
     html.replace(&html_to_replace_double, &html_replacement)
         .replace(&html_to_replace_single, &html_replacement)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::prep_html_shell;
+
+    const SHELL: &str = r#"
+<html>
+    <head>
+        <title>Shell</title>
+    </head>
+    <body>
+        <p>Content</p>
+    </body>
+</html>
+"#;
+
+    #[test]
+    fn some_example() {
+        let expected = "\n<html>\n    <head>\n<base href=\"prefix/\" />\n        <title>Shell</title>\n    <script>window.__PERSEUS_RENDER_CFG = '{}';</script>\n<script type=\"module\">\n    import init, { run } from \"prefix/.perseus/bundle.js\";\n    async function main() {\n        await init(\"prefix/.perseus/bundle.wasm\");\n        run();\n    }\n    main();\n</script>\n<!--PERSEUS_INTERPOLATED_HEAD_BEGINS-->\n</head>\n    <body>\n        <p>Content</p>\n    </body>\n</html>\n";
+        let result = prep_html_shell(String::from(SHELL), &HashMap::new(), "prefix");
+
+        assert_eq!(result, expected);
+    }
 }

--- a/packages/perseus/src/html_shell.rs
+++ b/packages/perseus/src/html_shell.rs
@@ -1,105 +1,141 @@
 use crate::page_data::PageData;
+use std::borrow::Cow;
 use std::collections::HashMap;
-use std::env;
+use std::{env, fmt};
 
-const INTERPOLATED_HEAD_MARKER: &str = "<!-- PERSEUS_INTERPOLATED_HEAD_BEGINS -->";
-
-struct HtmlShell {
-    inner: String,
-}
-
-impl HtmlShell {
-    /// Initializes the HTML shell by interpolating necessary scripts into it, as well as by adding the render configuration.
-    fn new(shell: &str, render_cfg: &HashMap<String, String>, path_prefix: &str) -> Self {
-        let set_testing_flag = if env::var("PERSEUS_TESTING").is_ok() {
-            "window.__PERSEUS_TESTING = true;"
-        } else {
-            ""
-        };
-
-        // Here is the list of things that we are adding *right after* the beginning of the <head> tag:
-        //
-        // - Render config as a global variable.
-        //
-        // - Global variable to identify whether we are testing (picked up by app shell to trigger helper DOM events).
-        //
-        // - A `<base>` tag with the base path of the app, which allows us to serve at relative paths just from an environment variable.
-        //
-        //      This one has to be at the very top of the <head> element so that it applies to everything in the HTML shell.
-        //      Otherwise any stylesheets loaded before it won't work properly.
-        //
-        //      Also add a trailing `/` to the path_prefix (https://stackoverflow.com/a/26043021);
-        //      note that it's already had any pre-existing ones stripped away.
-        //
-        let script = format!(
-            r#"
-        <base href="{path_prefix}/" />
-        <script type="module">
-            window.__PERSEUS_RENDER_CFG = '{render_config}';
-            {set_testing_flag}
-    
-            import init, {{ run }} from "{path_prefix}/.perseus/bundle.js";
-            async function main() {{
-                await init("{path_prefix}/.perseus/bundle.wasm");
-                run();
-            }}
-            main();
-        </script>
-        "#,
-            path_prefix = path_prefix,
-            render_config = serde_json::to_string(render_cfg).unwrap(),
-            set_testing_flag = set_testing_flag,
-        );
-
-        let shell = shell.replace("<head>", &format!("<head>{}", script));
-
-        // Append a delimiter comment that will be used to wall off the constant document head from the interpolated document head.
-        let shell = shell.replace("</head>", &format!("{}</head>", INTERPOLATED_HEAD_MARKER));
-        Self { inner: shell }
-    }
-
-    fn interpolate_page_data(self, page_data: &PageData, root_id: &str) {
-        let html_with_head = self.inner.replace(
-            INTERPOLATED_HEAD_MARKER,
-            &format!("{0}{1}", INTERPOLATED_HEAD_MARKER, &page_data.head),
-        );
-
-        // Interpolate a global variable of the state so the app shell doesn't have to make any more trips
-        // The app shell will unset this after usage so it doesn't contaminate later non-initial loads
-        // Error pages (above) will set this to `error`
-        let state_var = format!("<script>window.__PERSEUS_INITIAL_STATE = `{}`;</script>", {
-            if let Some(state) = &page_data.state {
-                state
-                    // We escape any backslashes to prevent their interfering with JSON delimiters
-                    .replace(r#"\"#, r#"\\"#)
-                    // We escape any backticks, which would interfere with JS's raw strings system
-                    .replace(r#"`"#, r#"\`"#)
-                    // We escape any interpolations into JS's raw string system
-                    .replace(r#"${"#, r#"\${"#)
-            } else {
-                "None".to_string()
-            }
-        });
-
-        let html_with_state = html_with_head.replace("</head>", &format!("{}\n</head>", state_var));
-    }
+/// Initializes the HTML shell by interpolating necessary scripts into it, as well as by adding the render configuration.
+#[derive(Clone)]
+pub struct HtmlShell<'a> {
+    shell: String,
+    prepend_elements: Vec<Cow<'a, str>>,
+    scripts: Vec<Cow<'a, str>>,
+    interpolated_content: Vec<Cow<'a, str>>,
+    interpolated_scripts: Vec<Cow<'a, str>>,
 }
 
 /// Interpolates content, metadata, and state into the HTML shell, ready to be sent to the user for initial loads. This should be passed
 /// an HTMl shell prepared with `prep_html_shell`. This also takes the HTML `id` of the element in the shell to interpolate content
 /// into.
-pub fn interpolate_page_data(html_shell: &str, page_data: &PageData, root_id: &str) -> String {
-    // Interpolate the document `<head>`
-    let html_with_head = html_shell.replace(
-        "<!--PERSEUS_INTERPOLATED_HEAD_BEGINS-->",
-        &format!("<!--PERSEUS_INTERPOLATED_HEAD_BEGINS-->{}", &page_data.head),
-    );
+pub struct HtmlShellWithPageData<'a> {
+    shell: HtmlShell<'a>,
+    content: &'a str,
+    root_id: &'a str,
+}
 
-    // Interpolate a global variable of the state so the app shell doesn't have to make any more trips
-    // The app shell will unset this after usage so it doesn't contaminate later non-initial loads
-    // Error pages (above) will set this to `error`
-    let state_var = format!("<script>window.__PERSEUS_INITIAL_STATE = `{}`;</script>", {
-        if let Some(state) = &page_data.state {
+/// Intepolates a fallback for locale redirection pages such that, even if JavaScript is disabled, the user will still be redirected to the default locale.
+/// From there, Perseus' inbuilt progressive enhancement can occur, but without this a user directed to an unlocalized page with JS disabled would see a
+/// blank screen, which is terrible UX. Note that this also includes a fallback for if JS is enabled but Wasm is disabled. Note that the redirect URL
+/// is expected to be generated with a path prefix inbuilt.
+///
+/// This also adds a `__perseus_initial_state` `<div>` in case it's needed (for Wasm redirections).
+pub struct HtmlShellWithRedirect<'a> {
+    shell: HtmlShell<'a>,
+    root_id: &'a str,
+}
+
+impl<'a> HtmlShell<'a> {
+    /// Initializes the HTML shell by interpolating necessary scripts into it, as well as by adding the render configuration.
+    pub fn new(shell: String, render_cfg: &HashMap<String, String>, path_prefix: &str) -> Self {
+        let mut prepend_elements = Vec::new();
+        let mut scripts = Vec::new();
+
+        // Define the render config as a global variable
+        let render_cfg = format!(
+            "window.__PERSEUS_RENDER_CFG = '{render_cfg}';",
+            // It's safe to assume that something we just deserialized will serialize again in this case
+            render_cfg = serde_json::to_string(render_cfg).unwrap()
+        );
+        scripts.push(render_cfg.into());
+
+        // Inject a global variable to identify whether we are testing (picked up by app shell to trigger helper DOM events)
+        if env::var("PERSEUS_TESTING").is_ok() {
+            scripts.push("window.__PERSEUS_TESTING = true;".into());
+        }
+
+        // Define the script that will load the Wasm bundle (inlined to avoid unnecessary extra requests)
+        let load_wasm_bundle = format!(
+            r#"
+        import init, {{ run }} from "{path_prefix}/.perseus/bundle.js";
+        async function main() {{
+            await init("{path_prefix}/.perseus/bundle.wasm");
+            run();
+        }}
+        main();
+        "#,
+            path_prefix = path_prefix
+        );
+        scripts.push(load_wasm_bundle.into());
+
+        // Add in the `<base>` element at the very top so that it applies to everything in the HTML shell
+        // Otherwise any stylesheets loaded before it won't work properly
+        //
+        // We add a trailing `/` to the base URL (https://stackoverflow.com/a/26043021)
+        // Note that it's already had any pre-existing ones stripped away
+        let base = format!(r#"<base href="{}/" />"#, path_prefix);
+        prepend_elements.push(base.into());
+
+        Self {
+            shell,
+            prepend_elements,
+            scripts,
+            interpolated_content: Vec::new(),
+            interpolated_scripts: Vec::new(),
+        }
+    }
+
+    /// Interpolates page data into the shell.
+    pub fn page_data(self, page_data: &'a PageData, root_id: &'a str) -> HtmlShellWithPageData<'a> {
+        HtmlShellWithPageData::new(self, page_data, root_id)
+    }
+
+    /// Interpolates redirection fallbacks into the shell.
+    pub fn locale_redirection_fallback(
+        self,
+        redirect_url: &'a str,
+        root_id: &'a str,
+    ) -> HtmlShellWithRedirect<'a> {
+        HtmlShellWithRedirect::new(self, redirect_url, root_id)
+    }
+}
+
+trait ShellWithContent {
+    fn shell(&self) -> &HtmlShell;
+    fn root_id(&self) -> &str;
+    fn content(&self) -> Option<&str>;
+}
+
+impl fmt::Display for HtmlShell<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // We also inject a delimiter comment that will be used to wall off the constant document head from the interpolated document head
+
+        let head_start = self.prepend_elements.join("\n");
+        let head_end = format!(
+            r#"
+            <script type="module">{scripts}</script>
+            <!--PERSEUS_INTERPOLATED_HEAD_BEGINS-->
+            {interpolated_content}
+            <script>{interpolated_scripts}</script>
+            "#,
+            scripts = self.scripts.join("\n"),
+            interpolated_content = self.interpolated_content.join("\n"),
+            interpolated_scripts = self.interpolated_scripts.join("\n"),
+        );
+
+        let new_shell = self
+            .shell
+            .replace("<head>", &format!("<head>{}", head_start))
+            .replace("</head>", &format!("{}</head>", head_end));
+
+        f.write_str(&new_shell)
+    }
+}
+
+impl<'a> HtmlShellWithPageData<'a> {
+    fn new(mut shell: HtmlShell<'a>, page_data: &'a PageData, root_id: &'a str) -> Self {
+        // Interpolate a global variable of the state so the app shell doesn't have to make any more trips
+        // The app shell will unset this after usage so it doesn't contaminate later non-initial loads
+        // Error pages (above) will set this to `error`
+        let initial_state = if let Some(state) = &page_data.state {
             state
                 // We escape any backslashes to prevent their interfering with JSON delimiters
                 .replace(r#"\"#, r#"\\"#)
@@ -109,111 +145,174 @@ pub fn interpolate_page_data(html_shell: &str, page_data: &PageData, root_id: &s
                 .replace(r#"${"#, r#"\${"#)
         } else {
             "None".to_string()
+        };
+
+        // We put this at the very end of the head (after the delimiter comment) because it doesn't matter if it's expunged on subsequent loads
+        let initial_state = format!("window.__PERSEUS_INITIAL_STATE = `{}`", initial_state);
+        shell.interpolated_scripts.push(initial_state.into());
+
+        // Interpolate the document `<head>`
+        shell.interpolated_content.push((&page_data.head).into());
+
+        Self {
+            shell,
+            content: &page_data.content,
+            root_id,
         }
-    });
-    // We put this at the very end of the head (after the delimiter comment) because it doesn't matter if it's expunged on subsequent loads
-    let html_with_state = html_with_head.replace("</head>", &format!("{}\n</head>", state_var));
-
-    // Figure out exactly what we're interpolating in terms of content
-    // The user MUST place have a `<div>` of this exact form (documented explicitly)
-    // We permit either double or single quotes
-    let html_to_replace_double = format!("<div id=\"{}\">", root_id);
-    let html_to_replace_single = format!("<div id='{}'>", root_id);
-    let html_replacement = format!(
-        // We give the content a specific ID so that it can be deleted if an error page needs to be rendered on the client-side
-        "{}<div id=\"__perseus_content_initial\" class=\"__perseus_content\">{}</div>",
-        &html_to_replace_double,
-        &page_data.content
-    );
-    // Now interpolate that HTML into the HTML shell
-    html_with_state
-        .replace(&html_to_replace_double, &html_replacement)
-        .replace(&html_to_replace_single, &html_replacement)
+    }
 }
 
-/// Intepolates a fallback for locale redirection pages such that, even if JavaScript is disabled, the user will still be redirected to the default locale.
-/// From there, Perseus' inbuilt progressive enhancement can occur, but without this a user directed to an unlocalized page with JS disabled would see a
-/// blank screen, which is terrible UX. Note that this also includes a fallback for if JS is enabled but Wasm is disabled. Note that the redirect URL
-/// is expected to be generated with a path prefix inbuilt.
-///
-/// This also adds a `__perseus_initial_state` `<div>` in case it's needed (for Wasm redirections).
-pub fn interpolate_locale_redirection_fallback(
-    html_shell: &str,
-    redirect_url: &str,
-    root_id: &str,
-) -> String {
-    // This will be used if JavaScript is completely disabled (it's then the site's responsibility to show a further message)
-    let dumb_redirector = format!(
-        r#"<noscript>
-    <meta http-equiv="refresh" content="0; url={}" />
-</noscript>"#,
-        redirect_url
-    );
-    // This will be used if JS is enabled, but Wasm is disabled or not supported (it's then the site's responsibility to show a further message)
-    // Wasm support detector courtesy https://stackoverflow.com/a/47880734
-    let js_redirector = format!(
-        r#"<script>
-    function wasmSupported() {{
-        try {{
-            if (typeof WebAssembly === "object"
-                && typeof WebAssembly.instantiate === "function") {{
-                const module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
-                if (module instanceof WebAssembly.Module) {{
-                    return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
+impl ShellWithContent for HtmlShellWithPageData<'_> {
+    fn shell(&self) -> &HtmlShell {
+        &self.shell
+    }
+
+    fn root_id(&self) -> &str {
+        self.root_id
+    }
+
+    fn content(&self) -> Option<&str> {
+        Some(self.content)
+    }
+}
+
+impl<'a> HtmlShellWithRedirect<'a> {
+    fn new(mut shell: HtmlShell<'a>, redirect_url: &'a str, root_id: &'a str) -> Self {
+        // This will be used if JavaScript is completely disabled (it's then the site's responsibility to show a further message)
+        let dumb_redirect = format!(
+            r#"<noscript>
+        <meta http-equiv="refresh" content="0; url={}" />
+    </noscript>"#,
+            redirect_url
+        );
+
+        // This will be used if JS is enabled, but Wasm is disabled or not supported (it's then the site's responsibility to show a further message)
+        // Wasm support detector courtesy https://stackoverflow.com/a/47880734
+        let js_redirect = format!(
+            r#"
+        function wasmSupported() {{
+            try {{
+                if (typeof WebAssembly === "object"
+                    && typeof WebAssembly.instantiate === "function") {{
+                    const module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
+                    if (module instanceof WebAssembly.Module) {{
+                        return new WebAssembly.Instance(module) instanceof WebAssembly.Instance;
+                    }}
                 }}
-            }}
-        }} catch (e) {{}}
-        return false;
-    }}
+            }} catch (e) {{}}
+            return false;
+        }}
+    
+        if (!wasmSupported()) {{
+            window.location.replace("{}");
+        }}
+            "#,
+            redirect_url
+        );
 
-    if (!wasmSupported()) {{
-        window.location.replace("{}");
-    }}
-</script>"#,
-        redirect_url
-    );
+        shell.interpolated_content.push(dumb_redirect.into());
+        shell.interpolated_scripts.push(js_redirect.into());
 
-    let html = html_shell.replace(
-        "</head>",
-        &format!("{}\n{}\n</head>", js_redirector, dumb_redirector),
-    );
-
-    // The user MUST place have a `<div>` of this exact form (documented explicitly)
-    // We permit either double or single quotes
-    let html_to_replace_double = format!("<div id=\"{}\">", root_id);
-    let html_to_replace_single = format!("<div id='{}'>", root_id);
-    let html_replacement = format!(
-        // We give the content a specific ID so that it can be deleted if an error page needs to be rendered on the client-side
-        "{}<div id=\"__perseus_content_initial\" class=\"__perseus_content\"></div>",
-        &html_to_replace_double,
-    );
-    // Now interpolate that HTML into the HTML shell
-    html.replace(&html_to_replace_double, &html_replacement)
-        .replace(&html_to_replace_single, &html_replacement)
+        Self { shell, root_id }
+    }
 }
+
+impl ShellWithContent for HtmlShellWithRedirect<'_> {
+    fn shell(&self) -> &HtmlShell {
+        &self.shell
+    }
+
+    fn root_id(&self) -> &str {
+        self.root_id
+    }
+
+    fn content(&self) -> Option<&str> {
+        None
+    }
+}
+
+macro_rules! impl_display_for_shell_with_content {
+    ($t:ident) => {
+        impl std::fmt::Display for $t<'_> {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                let shell = ShellWithContent::shell(self).to_string();
+                let root_id = ShellWithContent::root_id(self);
+                let content = match ShellWithContent::content(self) {
+                    Some(content) => content,
+                    None => "",
+                };
+
+                // The user MUST place have a `<div>` of this exact form (documented explicitly)
+                // We permit either double or single quotes
+                let html_to_replace_double = format!("<div id=\"{}\">", root_id);
+                let html_to_replace_single = format!("<div id='{}'>", root_id);
+                let html_replacement = format!(
+                    // We give the content a specific ID so that it can be deleted if an error page needs to be rendered on the client-side
+                    r#"{}<div id="__perseus_content_initial" class="__perseus_content">{}</div>"#,
+                    &html_to_replace_double, content,
+                );
+                // Now interpolate that HTML into the HTML shell
+                let new_shell = shell
+                    .replace(&html_to_replace_double, &html_replacement)
+                    .replace(&html_to_replace_single, &html_replacement);
+
+                f.write_str(&new_shell)
+            }
+        }
+    };
+}
+
+impl_display_for_shell_with_content!(HtmlShellWithPageData);
+impl_display_for_shell_with_content!(HtmlShellWithRedirect);
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use crate::page_data::PageData;
+    use std::{collections::HashMap, iter::FromIterator};
 
-    use super::prep_html_shell;
+    use super::HtmlShell;
 
     const SHELL: &str = r#"
-<html>
-    <head>
-        <title>Shell</title>
-    </head>
-    <body>
-        <p>Content</p>
-    </body>
-</html>
-"#;
+    <html>
+        <head>
+            <title>Shell</title>
+        </head>
+        <body>
+            <p>Content</p>
+            <div id="root_id"></div>
+        </body>
+    </html>
+    "#;
+
+    fn get_render_config() -> HashMap<String, String> {
+        HashMap::from_iter([("key".into(), "value".into())])
+    }
 
     #[test]
-    fn some_example() {
-        let expected = "\n<html>\n    <head>\n<base href=\"prefix/\" />\n        <title>Shell</title>\n    <script>window.__PERSEUS_RENDER_CFG = '{}';</script>\n<script type=\"module\">\n    import init, { run } from \"prefix/.perseus/bundle.js\";\n    async function main() {\n        await init(\"prefix/.perseus/bundle.wasm\");\n        run();\n    }\n    main();\n</script>\n<!--PERSEUS_INTERPOLATED_HEAD_BEGINS-->\n</head>\n    <body>\n        <p>Content</p>\n    </body>\n</html>\n";
-        let result = prep_html_shell(String::from(SHELL), &HashMap::new(), "prefix");
+    fn basic_shell() {
+        let shell = HtmlShell::new(SHELL.into(), &get_render_config(), "prefix");
+        println!("{}", shell);
+    }
 
-        assert_eq!(result, expected);
+    #[test]
+    fn page_data_shell() {
+        let page_data = PageData {
+            content: "page_data.content".to_string(),
+            state: Some("page_data.state".to_string()),
+            head: "page_data.head".to_string(),
+        };
+
+        let shell = HtmlShell::new(SHELL.into(), &get_render_config(), "prefix")
+            .page_data(&page_data, "root_id");
+
+        println!("{}", shell);
+    }
+
+    #[test]
+    fn redirect_fallback_shell() {
+        let shell = HtmlShell::new(SHELL.into(), &get_render_config(), "prefix")
+            .locale_redirection_fallback("redirect_url", "root_id");
+
+        println!("{}", shell);
     }
 }


### PR DESCRIPTION
I've added some tests to `html_shell.rs`. They don't really assert anything, but I used them to be able to quickly print out the output while refactoring to make sure that it looks right. I figured I'd leave them in for now in case you wanted to try running the code yourself while reviewing.

`window.__PERSEUS_RENDER_CFG` now gets defined at the top of `<head>` instead of bottom, but I don't think that should change much. You know the code better than me though, so I figured I'd mention it just in case.

I tried running the tests on my laptop, but they took a really long time since my specs aren't that great and I also ran into an issue with `geckodriver`. Maybe you could run the tests in CI?

Let me know if you think there's more room for improvement or something should be changed!

Closes #108 