### PR TITLE
Improve type safety for time-based revalidation

### DIFF
--- a/examples/showcase/src/templates/time.rs
+++ b/examples/showcase/src/templates/time.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use perseus::{
     ErrorCause, GenericErrorWithCause, RenderFnResult, RenderFnResultWithCause, Template,
 };
@@ -21,7 +23,7 @@ pub fn get_template<G: Html>() -> Template<G> {
     Template::new("timeisr")
         .template(time_page)
         // This page will revalidate every five seconds (to illustrate revalidation)
-        .revalidate_after("5s".to_string())
+        .revalidate_after(Duration::new(5, 0))
         .incremental_generation()
         .build_state_fn(get_build_state)
         .build_paths_fn(get_build_paths)

--- a/examples/showcase/src/templates/time_root.rs
+++ b/examples/showcase/src/templates/time_root.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use perseus::{RenderFnResultWithCause, Template};
 use serde::{Deserialize, Serialize};
 use sycamore::prelude::{component, view, Html, View};
@@ -20,7 +22,7 @@ pub fn get_template<G: Html>() -> Template<G> {
         .template(time_page)
         // This page will revalidate every five seconds (to illustrate revalidation)
         // Try changing this to a week, even though the below custom logic says to always revalidate, we'll only do it weekly
-        .revalidate_after("5s".to_string())
+        .revalidate_after(Duration::new(5, 0))
         .should_revalidate_fn(|| async { Ok(true) })
         .build_state_fn(get_build_state)
 }

--- a/packages/perseus/src/build.rs
+++ b/packages/perseus/src/build.rs
@@ -6,7 +6,6 @@ use crate::templates::TemplateMap;
 use crate::translations_manager::TranslationsManager;
 use crate::translator::Translator;
 use crate::{
-    decode_time_str::decode_time_str,
     stores::{ImmutableStore, MutableStore},
     Template,
 };
@@ -166,7 +165,10 @@ async fn gen_state_for_path(
     // Handle revalidation, we need to parse any given time strings into datetimes
     // We don't need to worry about revalidation that operates by logic, that's request-time only
     if template.revalidates_with_time() {
-        let datetime_to_revalidate = decode_time_str(&template.get_revalidate_interval().unwrap())?;
+        let datetime_to_revalidate = template
+            .get_revalidate_interval()
+            .unwrap()
+            .compute_timestamp();
         // Write that to a static file, we'll update it every time we revalidate
         // Note that this runs for every path generated, so it's fully usable with ISR
         // Yes, there's a different revalidation schedule for each locale, but that means we don't have to rebuild every locale simultaneously

--- a/packages/perseus/src/decode_time_str.rs
+++ b/packages/perseus/src/decode_time_str.rs
@@ -1,55 +1,20 @@
-use crate::errors::*;
-use chrono::{Duration, Utc};
+use chrono::Utc;
+use std::time;
 
-// Decodes time strings like '1w' into actual datetimes from the present moment. If you've ever used NodeJS's [`jsonwebtoken`](https://www.npmjs.com/package/jsonwebtoken) module, this is
-/// very similar (based on Vercel's [`ms`](https://github.com/vercel/ms) module for JavaScript).
-/// Accepts strings of the form 'xXyYzZ...', where the lower-case letters are numbers meaning a number of the intervals X/Y/Z (e.g. 1m4d -- one month four days).
-/// The available intervals are:
-///
-/// - s: second,
-/// - m: minute,
-/// - h: hour,
-/// - d: day,
-/// - w: week,
-/// - M: month (30 days used here, 12M ≠ 1y!),
-/// - y: year (365 days always, leap years ignored, if you want them add them as days)
-pub fn decode_time_str(time_str: &str) -> Result<String, BuildError> {
-    let mut duration_after_current = Duration::zero();
-    // Get the current datetime since Unix epoch, we'll add to that
-    let current = Utc::now();
-    // A working variable to store the '123' part of an interval until we reach the idnicator and can do the full conversion
-    let mut curr_duration_length = String::new();
-    // Iterate through the time string's characters to get each interval
-    for c in time_str.chars() {
-        // If we have a number, append it to the working cache
-        // If we have an indicator character, we'll match it to a duration
-        if c.is_numeric() {
-            curr_duration_length.push(c);
-        } else {
-            // Parse the working variable into an actual number
-            let interval_length = curr_duration_length.parse::<i64>().unwrap(); // It's just a string of numbers, we know more than the compiler
-            let duration = match c {
-                's' => Duration::seconds(interval_length),
-                'm' => Duration::minutes(interval_length),
-                'h' => Duration::hours(interval_length),
-                'd' => Duration::days(interval_length),
-                'w' => Duration::weeks(interval_length),
-                'M' => Duration::days(interval_length * 30), // Multiplying the number of months by 30 days (assumed length of a month)
-                'y' => Duration::days(interval_length * 365), // Multiplying the number of years by 365 days (assumed length of a year)
-                c => {
-                    return Err(BuildError::InvalidDatetimeIntervalIndicator {
-                        indicator: c.to_string(),
-                    })
-                }
-            };
-            duration_after_current = duration_after_current + duration;
-            // Reset that working variable
-            curr_duration_length = String::new();
-        }
+/// Represents a duration that can be computed relative to the current time.
+#[derive(Debug, Clone)]
+pub struct ComputedDuration(chrono::Duration);
+
+impl ComputedDuration {
+    pub fn new<I: Into<time::Duration>>(duration: I) -> Self {
+        let duration = chrono::Duration::from_std(duration.into()).unwrap();
+        Self(duration)
     }
-    // Form the final duration by reducing the durations vector into one
-    let datetime = current + duration_after_current;
 
-    // We return an easily parsible format (RFC 3339)
-    Ok(datetime.to_rfc3339())
+    /// Get the timestamp of the duration added to the current time.
+    pub fn compute_timestamp(&self) -> String {
+        let current = Utc::now();
+        let datetime = current + self.0;
+        datetime.to_rfc3339()
+    }
 }

--- a/packages/perseus/src/decode_time_str.rs
+++ b/packages/perseus/src/decode_time_str.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use std::time;
+use std::{convert::TryFrom, time};
 
 /// Represents a duration that can be computed relative to the current time.
 #[derive(Debug, Clone)]
@@ -16,5 +16,71 @@ impl ComputedDuration {
         let current = Utc::now();
         let datetime = current + self.0;
         datetime.to_rfc3339()
+    }
+}
+
+#[derive(Default)]
+pub struct Duration {
+    years: i64,
+    months: i64,
+    weeks: i64,
+    days: i64,
+    hours: i64,
+    minutes: i64,
+    seconds: i64,
+}
+
+pub struct InvalidDuration;
+
+impl From<Duration> for time::Duration {
+    fn from(duration: Duration) -> Self {
+        let duration = chrono::Duration::seconds(duration.seconds)
+            + chrono::Duration::minutes(duration.minutes)
+            + chrono::Duration::hours(duration.hours)
+            + chrono::Duration::days(duration.days)
+            + chrono::Duration::weeks(duration.weeks)
+            + chrono::Duration::days(duration.months * 30)  // Assumed length of a month
+            + chrono::Duration::days(duration.years * 365); // Assumed length of a year
+
+        duration.to_std().unwrap()
+    }
+}
+
+impl TryFrom<&str> for Duration {
+    type Error = InvalidDuration;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let mut duration = Self::default();
+
+        // A working variable to store the '123' part of an interval until we reach the indicator and can do the full conversion
+        let mut curr_duration_length = String::new();
+
+        for c in value.chars() {
+            // If we have a number, append it to the working cache
+            // If we have an indicator character, we'll match it to a duration
+            if c.is_numeric() {
+                curr_duration_length.push(c);
+            } else {
+                let interval_length: i64 = curr_duration_length.parse().unwrap(); // It's just a string of numbers, we know more than the compiler
+                if interval_length <= 0 {
+                    return Err(InvalidDuration);
+                }
+
+                match c {
+                    's' if duration.seconds == 0 => duration.seconds = interval_length,
+                    'm' if duration.minutes == 0 => duration.minutes = interval_length,
+                    'h' if duration.hours == 0 => duration.hours = interval_length,
+                    'd' if duration.days == 0 => duration.days = interval_length,
+                    'w' if duration.weeks == 0 => duration.weeks = interval_length,
+                    'M' if duration.months == 0 => duration.months = interval_length,
+                    'y' if duration.years == 0 => duration.years = interval_length,
+                    _ => return Err(InvalidDuration),
+                };
+
+                curr_duration_length = String::new();
+            }
+        }
+
+        Ok(duration)
     }
 }

--- a/packages/perseus/src/server/render.rs
+++ b/packages/perseus/src/server/render.rs
@@ -1,4 +1,3 @@
-use crate::decode_time_str::decode_time_str;
 use crate::errors::*;
 use crate::page_data::PageData;
 use crate::stores::{ImmutableStore, MutableStore};
@@ -168,7 +167,10 @@ async fn revalidate(
     if template.revalidates_with_time() {
         // IMPORTANT: we set the new revalidation datetime to the interval from NOW, not from the previous one
         // So if you're revalidating many pages weekly, they will NOT revalidate simultaneously, even if they're all queried thus
-        let datetime_to_revalidate = decode_time_str(&template.get_revalidate_interval().unwrap())?;
+        let datetime_to_revalidate = template
+            .get_revalidate_interval()
+            .unwrap()
+            .compute_timestamp();
         mutable_store
             .write(
                 &format!("static/{}.revld.txt", path_encoded),
@@ -281,8 +283,10 @@ pub async fn get_page_for_template(
                     // We don't need to worry about revalidation that operates by logic, that's request-time only
                     // Obviously we don't need to revalidate now, we just created it
                     if template.revalidates_with_time() {
-                        let datetime_to_revalidate =
-                            decode_time_str(&template.get_revalidate_interval().unwrap())?;
+                        let datetime_to_revalidate = template
+                            .get_revalidate_interval()
+                            .unwrap()
+                            .compute_timestamp();
                         // Write that to a static file, we'll update it every time we revalidate
                         // Note that this runs for every path generated, so it's fully usable with ISR
                         mutable_store


### PR DESCRIPTION
This PR changes this property:

```rust
pub struct Template<G: Html> {
    ...
    revalidate_after: Option<String>,
    ...
}
```

Instead of using a `String` to represent a duration of time, we use a dedicated Rust type in order to improve type safety.

This PR is a breaking change.

Closes #111 