### PR TITLE
Add router state

### DIFF
--- a/docs/next/en-US/SUMMARY.md
+++ b/docs/next/en-US/SUMMARY.md
@@ -15,6 +15,7 @@
 -   [Templates and Routing](/docs/templates/intro)
     -   [Modifying the `<head>`](/docs/templates/metadata-modification)
     -   [Modifying HTTP Headers](/docs/templates/setting-headers)
+    -   [Listening to the Router](/docs/templates/router-state)
 -   [Error Pages](/docs/error-pages)
 -   [Static Content](/docs/static-content)
 -   [Internationalization](/docs/i18n/intro)

--- a/docs/next/en-US/templates/router-state.md
+++ b/docs/next/en-US/templates/router-state.md
@@ -1,0 +1,19 @@
+# Listening to the Router
+
+Given that Perseus loads new pages without reloading the browser tab, users will have no way to know that their clicking on a link actually did anything, which can be extremely annoying for your users, and may even dissaude them from using your site! Usually, this is circumvented by how quickly Perseus can load a new page, but, if a user happens to be on a particularly slow connection, it could take several seconds.
+
+To avoid this, many modern frameworks support a loading bar at the top of the page to show that something is actully happening. Some sites prefer a more intrusive full page overlay with a loading indicator. No matter what approach you choose, Perseus gets out of your way and lets you build it, by using *router state*. This is a Sycamore `ReadSignal` that you can get access to in your templates and then use to listen for events on the router.
+
+## Usage
+
+This example (taken from [here](https://github.com/arctic-hen7/perseus/blob/main/examples/showcase/src/templates/router_state.rs)) shows using router state to create a simple indicator of the router's current state, though this could easily be extended into a progress bar, loading indicator, or the like.
+
+```rust
+{{#include ../../../../examples/showcase/src/templates/router_state.rs}}
+```
+
+The first step in using router state is accessing it, which can be done through Sycamore's [context API](https://sycamore-rs.netlify.app/docs/advanced/contexts). Specifically, we access the context of type `perseus::templates::RenderCtx` (which also includes other information), which has a field `router_state`, which contains an instance of `perseus::templates::RouterState`. Then, we can use the `.get_load_state()` method on that to get a `ReadSignal<perseus::templates::RouterLoadState>` (Sycamore-speak for a read-only piece of state). Next, we use Sycamore's `create_memo` to create some derived state (so it will update whenever the router's loading state does) that just turns the router's state into a string to render for the user.
+
+As you can see, there are three mutually exclusive states the router can be in: `Loaded`, `Loading`, and `Server`. The first two of these have an attached `String` that indicates either the name of the template that has been loaded (in the first case) or the name of the template that is about to be loaded (in the second case). In the third state, you shouldn't do anything, because no router actually exists, as the page is being rendered on the server. Note that anything rendered in the `Server` state will be visible for a brief moment in the browser before the page is made interactive, which can cause ugly UI flashes. 
+
+As noted in the comments in this code, if you were to load this page and click the link to the `/about` page (which has the template name `about`), you would momentarily see `Loading about.` before the page loaded. During this time (i.e. when the router is in the `Loading` state), you may want to render some kind of progress bar or overlay to indicate to the user that a new page is being loaded.

--- a/examples/showcase/src/lib.rs
+++ b/examples/showcase/src/lib.rs
@@ -12,7 +12,8 @@ define_app! {
         crate::templates::ip::get_template::<G>(),
         crate::templates::time_root::get_template::<G>(),
         crate::templates::time::get_template::<G>(),
-        crate::templates::amalgamation::get_template::<G>()
+        crate::templates::amalgamation::get_template::<G>(),
+        crate::templates::router_state::get_template::<G>()
     ],
     error_pages: crate::error_pages::get_error_pages(),
     locales: {

--- a/examples/showcase/src/templates/mod.rs
+++ b/examples/showcase/src/templates/mod.rs
@@ -4,5 +4,6 @@ pub mod index;
 pub mod ip;
 pub mod new_post;
 pub mod post;
+pub mod router_state;
 pub mod time;
 pub mod time_root;

--- a/examples/showcase/src/templates/router_state.rs
+++ b/examples/showcase/src/templates/router_state.rs
@@ -1,0 +1,28 @@
+use perseus::{templates::RouterLoadState, Html, Template};
+use sycamore::prelude::{cloned, component, create_memo, view, View};
+
+#[perseus::template(RouterStatePage)]
+#[component(RouterStatePage<G>)]
+pub fn router_state_page() -> View<G> {
+    let load_state = sycamore::context::use_context::<perseus::templates::RenderCtx>()
+        .router
+        .get_load_state();
+    let load_state_str = create_memo(
+        cloned!(load_state => move || match (*load_state.get()).clone() {
+            RouterLoadState::Loaded(name) => format!("Loaded {}.", name),
+            RouterLoadState::Loading(new) => format!("Loading {}.", new),
+            RouterLoadState::Server => "We're on the server.".to_string()
+        }),
+    );
+
+    view! {
+        a(href = "about", id = "about-link") { "About!" }
+
+
+        p { (load_state_str.get()) }
+    }
+}
+
+pub fn get_template<G: Html>() -> Template<G> {
+    Template::new("router_state").template(router_state_page)
+}

--- a/packages/perseus/src/build.rs
+++ b/packages/perseus/src/build.rs
@@ -2,6 +2,7 @@
 
 use crate::errors::*;
 use crate::locales::Locales;
+use crate::router::RouterState;
 use crate::templates::TemplateMap;
 use crate::translations_manager::TranslationsManager;
 use crate::translator::Translator;
@@ -117,7 +118,12 @@ async fn gen_state_for_path(
             .await?;
         // Prerender the template using that state
         let prerendered = sycamore::render_to_string(|| {
-            template.render_for_template(Some(initial_state.clone()), translator, true)
+            template.render_for_template(
+                Some(initial_state.clone()),
+                translator,
+                true,
+                RouterState::default(),
+            )
         });
         // Write that prerendered HTML to a static file
         mutable_store
@@ -146,7 +152,12 @@ async fn gen_state_for_path(
             .await?;
         // Prerender the template using that state
         let prerendered = sycamore::render_to_string(|| {
-            template.render_for_template(Some(initial_state.clone()), translator, true)
+            template.render_for_template(
+                Some(initial_state.clone()),
+                translator,
+                true,
+                RouterState::default(),
+            )
         });
         // Write that prerendered HTML to a static file
         immutable_store
@@ -184,8 +195,9 @@ async fn gen_state_for_path(
     // If the template is very basic, prerender without any state
     // It's safe to add a property to the render options here because `.is_basic()` will only return true if path generation is not being used (or anything else)
     if template.is_basic() {
-        let prerendered =
-            sycamore::render_to_string(|| template.render_for_template(None, translator, true));
+        let prerendered = sycamore::render_to_string(|| {
+            template.render_for_template(None, translator, true, RouterState::default())
+        });
         let head_str = template.render_head_str(None, translator);
         // Write that prerendered HTML to a static file
         immutable_store

--- a/packages/perseus/src/lib.rs
+++ b/packages/perseus/src/lib.rs
@@ -84,6 +84,7 @@ pub use crate::template::{HeadFn, RenderFnResult, RenderFnResultWithCause, State
 /// Utilities for developing templates, particularly including return types for various rendering strategies.
 pub mod templates {
     pub use crate::errors::{ErrorCause, GenericErrorWithCause};
+    pub use crate::router::{RouterLoadState, RouterState};
     pub use crate::template::*;
     // The engine needs to know whether or not to use hydration, this is how we pass those feature settings through
     #[cfg(not(feature = "hydrate"))]

--- a/packages/perseus/src/plugins/plugins_list.rs
+++ b/packages/perseus/src/plugins/plugins_list.rs
@@ -33,11 +33,13 @@ impl<G: Html> Plugins<G> {
     /// Registers a new plugin, consuming `self`. For control actions, this will check if a plugin has already registered on an action,
     /// and throw an error if one has, noting the conflict explicitly in the error message. This can only register plugins that run
     /// exclusively on the server-side (including tinker-time and the build process).
+    // We allow unusued variables and the like for linting because otherwise any errors in Wasm compilation will show these up, which is annoying
     pub fn plugin<D: Any + Send>(
-        mut self,
+        #[cfg_attr(target_arch = "wasm32", allow(unused_mut))] mut self,
         // This is a function so that it never gets called if we're compiling for Wasm, which means Rust eliminates it as dead code!
-        plugin: impl Fn() -> Plugin<G, D> + Send,
-        plugin_data: D,
+        #[cfg_attr(target_arch = "wasm32", allow(unused_variables))] plugin: impl Fn() -> Plugin<G, D>
+            + Send,
+        #[cfg_attr(target_arch = "wasm32", allow(unused_variables))] plugin_data: D,
     ) -> Self {
         // If we're compiling for Wasm, plugins that don't run on the client side shouldn't be added (they'll then be eliminated as dead code)
         #[cfg(not(target_arch = "wasm32"))]

--- a/packages/perseus/src/router.rs
+++ b/packages/perseus/src/router.rs
@@ -5,6 +5,8 @@ use crate::Html;
 use crate::Template;
 use std::collections::HashMap;
 use std::rc::Rc;
+use sycamore::prelude::ReadSignal;
+use sycamore::prelude::Signal;
 
 /// The backend for `get_template_for_path` to avoid code duplication for the `Arc` and `Rc` versions.
 macro_rules! get_template_for_path {
@@ -289,4 +291,40 @@ macro_rules! create_app_route {
             }
         }
     };
+}
+
+/// The state for the router.
+#[derive(Clone)]
+pub struct RouterState {
+    /// The router's current load state.
+    load_state: Signal<RouterLoadState>,
+}
+impl Default for RouterState {
+    /// Creates a default instance of the router state intended for server-side usage.
+    fn default() -> Self {
+        Self {
+            load_state: Signal::new(RouterLoadState::Server),
+        }
+    }
+}
+impl RouterState {
+    /// Gets the load state of the router.
+    pub fn get_load_state(&self) -> ReadSignal<RouterLoadState> {
+        self.load_state.handle()
+    }
+    /// Sets the load state of the router.
+    pub fn set_load_state(&self, new: RouterLoadState) {
+        self.load_state.set(new);
+    }
+}
+
+/// The current load state of the router. You can use this to be warned of when a new page is about to be loaded (and display a loading bar or the like, perhaps).
+#[derive(Clone)]
+pub enum RouterLoadState {
+    /// The page has been loaded. The name of the template is attached.
+    Loaded(String),
+    /// A new page is being loaded, and will soon replace whatever is currently loaded. The name of the new template is attached.
+    Loading(String),
+    /// We're on the server, and there is no router. Whatever you render based on this state will appear when the user first loads the page, before it's made interactive.
+    Server,
 }

--- a/packages/perseus/src/server/render.rs
+++ b/packages/perseus/src/server/render.rs
@@ -1,6 +1,7 @@
 use crate::decode_time_str::decode_time_str;
 use crate::errors::*;
 use crate::page_data::PageData;
+use crate::router::RouterState;
 use crate::stores::{ImmutableStore, MutableStore};
 use crate::template::{States, Template, TemplateMap};
 use crate::translations_manager::TranslationsManager;
@@ -75,7 +76,7 @@ async fn render_request_state(
     );
     // Use that to render the static HTML
     let html = sycamore::render_to_string(|| {
-        template.render_for_template(state.clone(), translator, true)
+        template.render_for_template(state.clone(), translator, true, RouterState::default())
     });
     let head = template.render_head_str(state.clone(), translator);
 
@@ -160,7 +161,7 @@ async fn revalidate(
             .await?,
     );
     let html = sycamore::render_to_string(|| {
-        template.render_for_template(state.clone(), translator, true)
+        template.render_for_template(state.clone(), translator, true, RouterState::default())
     });
     let head = template.render_head_str(state.clone(), translator);
     // Handle revalidation, we need to parse any given time strings into datetimes
@@ -274,7 +275,12 @@ pub async fn get_page_for_template(
                             .await?,
                     );
                     let html_val = sycamore::render_to_string(|| {
-                        template.render_for_template(state.clone(), &translator, true)
+                        template.render_for_template(
+                            state.clone(),
+                            &translator,
+                            true,
+                            RouterState::default(),
+                        )
                     });
                     let head_val = template.render_head_str(state.clone(), &translator);
                     // Handle revalidation, we need to parse any given time strings into datetimes

--- a/packages/perseus/src/shell.rs
+++ b/packages/perseus/src/shell.rs
@@ -273,22 +273,21 @@ pub async fn app_shell(
 
             let path = template.get_path();
             // Hydrate that static code using the acquired state
+            let router_state_2 = router_state.clone();
             // BUG (Sycamore): this will double-render if the component is just text (no nodes)
             #[cfg(not(feature = "hydrate"))]
             {
                 // If we aren't hydrating, we'll have to delete everything and re-render
                 container_rx_elem.set_inner_html("");
                 sycamore::render_to(
-                    move || {
-                        template.render_for_template(state, translator, false, router_state.clone())
-                    },
+                    move || template.render_for_template(state, translator, false, router_state_2),
                     &container_rx_elem,
                 );
             }
             #[cfg(feature = "hydrate")]
             sycamore::hydrate_to(
                 // This function provides translator context as needed
-                || template.render_for_template(state, translator, false, router_state.clone()),
+                || template.render_for_template(state, translator, false, router_state_2),
                 &container_rx_elem,
             );
             checkpoint("page_interactive");

--- a/packages/perseus/src/shell.rs
+++ b/packages/perseus/src/shell.rs
@@ -4,7 +4,7 @@ use crate::errors::*;
 use crate::page_data::PageData;
 use crate::path_prefix::get_path_prefix_client;
 use crate::template::Template;
-use crate::templates::TemplateNodeType;
+use crate::templates::{RouterLoadState, RouterState, TemplateNodeType};
 use crate::ErrorPages;
 use fmterr::fmt_err;
 use std::cell::RefCell;
@@ -217,11 +217,14 @@ pub async fn app_shell(
     path: String,
     (template, was_incremental_match): (Rc<Template<TemplateNodeType>>, bool),
     locale: String,
+    router_state: RouterState,
     translations_manager: Rc<RefCell<ClientTranslationsManager>>,
     error_pages: Rc<ErrorPages<DomNode>>,
     (initial_container, container_rx_elem): (Element, Element), // The container that the server put initial load content into and the reactive container tht we'll actually use
 ) {
     checkpoint("app_shell_entry");
+    // Update the router state
+    router_state.set_load_state(RouterLoadState::Loading(template.get_path()));
     // Check if this was an initial load and we already have the state
     let initial_state = get_initial_state();
     match initial_state {
@@ -268,6 +271,7 @@ pub async fn app_shell(
                 }
             };
 
+            let path = template.get_path();
             // Hydrate that static code using the acquired state
             // BUG (Sycamore): this will double-render if the component is just text (no nodes)
             #[cfg(not(feature = "hydrate"))]
@@ -275,17 +279,21 @@ pub async fn app_shell(
                 // If we aren't hydrating, we'll have to delete everything and re-render
                 container_rx_elem.set_inner_html("");
                 sycamore::render_to(
-                    move || template.render_for_template(state, translator, false),
+                    move || {
+                        template.render_for_template(state, translator, false, router_state.clone())
+                    },
                     &container_rx_elem,
                 );
             }
             #[cfg(feature = "hydrate")]
             sycamore::hydrate_to(
                 // This function provides translator context as needed
-                || template.render_for_template(state, translator, false),
+                || template.render_for_template(state, translator, false, router_state.clone()),
                 &container_rx_elem,
             );
             checkpoint("page_interactive");
+            // Update the router state
+            router_state.set_load_state(RouterLoadState::Loaded(path));
         }
         // If we have no initial state, we should proceed as usual, fetching the content and state from the server
         InitialState::NotPresent => {
@@ -359,6 +367,7 @@ pub async fn app_shell(
                                 };
 
                                 // Hydrate that static code using the acquired state
+                                let router_state_2 = router_state.clone();
                                 // BUG (Sycamore): this will double-render if the component is just text (no nodes)
                                 #[cfg(not(feature = "hydrate"))]
                                 {
@@ -370,6 +379,7 @@ pub async fn app_shell(
                                                 page_data.state,
                                                 translator,
                                                 false,
+                                                router_state_2.clone(),
                                             )
                                         },
                                         &container_rx_elem,
@@ -383,11 +393,14 @@ pub async fn app_shell(
                                             page_data.state,
                                             translator,
                                             false,
+                                            router_state_2,
                                         )
                                     },
                                     &container_rx_elem,
                                 );
                                 checkpoint("page_interactive");
+                                // Update the router state
+                                router_state.set_load_state(RouterLoadState::Loaded(path));
                             }
                             // If the page failed to serialize, an exception has occurred
                             Err(err) => panic!("page data couldn't be serialized: '{}'", err),


### PR DESCRIPTION
This adds support for router state to Perseus, including a new example in `examples/showcase/` and documentation in the section on templates. It's likely that the router state provided will be extended in future, but, for now, it includes just one property about the router's load state, which can be used to create custom routing progress bars and the like.

Closes #106.