### PR TITLE
Fix hydration by not inserting hydration keys in `<head>`

### DIFF
--- a/examples/core/basic/.perseus/Cargo.toml
+++ b/examples/core/basic/.perseus/Cargo.toml
@@ -13,8 +13,8 @@ edition = "2021"
 app = { package = "perseus-example-basic", path = "../" }
 
 perseus = { path = "../../../../packages/perseus" }
-sycamore = { version = "=0.8.0-beta.4", features = ["ssr"] }
-sycamore-router = "=0.8.0-beta.4"
+sycamore = { version = "=0.8.0-beta.5", features = ["ssr"] }
+sycamore-router = "=0.8.0-beta.5"
 web-sys = { version = "0.3", features = ["Event", "Headers", "Request", "RequestInit", "RequestMode", "Response", "ReadableStream", "Window"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/examples/core/basic/Cargo.toml
+++ b/examples/core/basic/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/examples/core/basic/Cargo.toml
+++ b/examples/core/basic/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-perseus = { path = "../../../packages/perseus", features = ["hydrate"] }
+perseus = { path = "../../../packages/perseus", features = [] }
 sycamore = "=0.8.0-beta.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/core/basic/Cargo.toml
+++ b/examples/core/basic/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-perseus = { path = "../../../packages/perseus", features = [] }
+perseus = { path = "../../../packages/perseus", features = ["hydrate"] }
 sycamore = "=0.8.0-beta.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/core/freezing_and_thawing/Cargo.toml
+++ b/examples/core/freezing_and_thawing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "hydrate" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/examples/core/global_state/Cargo.toml
+++ b/examples/core/global_state/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "hydrate" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/examples/core/i18n/Cargo.toml
+++ b/examples/core/i18n/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "translator-fluent", "hydrate" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 fluent-bundle = "0.15"

--- a/examples/core/idb_freezing/Cargo.toml
+++ b/examples/core/idb_freezing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "hydrate", "idb-freezing" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 wasm-bindgen-futures = "0.4"

--- a/examples/core/plugins/Cargo.toml
+++ b/examples/core/plugins/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus" }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 toml = "0.5"

--- a/examples/core/router_state/Cargo.toml
+++ b/examples/core/router_state/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "hydrate" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/core/rx_state/Cargo.toml
+++ b/examples/core/rx_state/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "hydrate" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/examples/core/set_headers/Cargo.toml
+++ b/examples/core/set_headers/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "hydrate" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/examples/core/state_generation/Cargo.toml
+++ b/examples/core/state_generation/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "hydrate" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/examples/core/static_content/Cargo.toml
+++ b/examples/core/static_content/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [ "hydrate" ] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/examples/core/unreactive/Cargo.toml
+++ b/examples/core/unreactive/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 perseus = { path = "../../../packages/perseus", features = [] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/packages/perseus-actix-web/Cargo.toml
+++ b/packages/perseus-actix-web/Cargo.toml
@@ -25,4 +25,4 @@ serde_json = "1"
 thiserror = "1"
 fmterr = "0.1"
 futures = "0.3"
-sycamore = { version = "=0.8.0-beta.4", features = ["ssr"] }
+sycamore = { version = "=0.8.0-beta.5", features = ["ssr"] }

--- a/packages/perseus-macro/Cargo.toml
+++ b/packages/perseus-macro/Cargo.toml
@@ -25,11 +25,11 @@ syn = "1"
 proc-macro2 = "1"
 darling = "0.13"
 serde_json = "1"
-sycamore-reactive = "=0.8.0-beta.4"
+sycamore-reactive = "=0.8.0-beta.5"
 
 [dev-dependencies]
 trybuild = { version = "1.0", features = ["diff"] }
-sycamore = "=0.8.0-beta.4"
+sycamore = "=0.8.0-beta.5"
 serde = { version = "1", features = [ "derive" ] }
 
 [features]

--- a/packages/perseus-warp/Cargo.toml
+++ b/packages/perseus-warp/Cargo.toml
@@ -23,4 +23,4 @@ serde_json = "1"
 thiserror = "1"
 fmterr = "0.1"
 futures = "0.3"
-sycamore = { version = "=0.8.0-beta.4", features = ["ssr"] }
+sycamore = { version = "=0.8.0-beta.5", features = ["ssr"] }

--- a/packages/perseus/Cargo.toml
+++ b/packages/perseus/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["wasm", "web-programming", "development-tools", "asynchronous", "g
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sycamore = { version = "=0.8.0-beta.4", features = [ "ssr" ] }
-sycamore-router = "=0.8.0-beta.4"
-sycamore-futures = "=0.8.0-beta.4"
+sycamore = { version = "=0.8.0-beta.5", features = [ "ssr" ] }
+sycamore-router = "=0.8.0-beta.5"
+sycamore-futures = "=0.8.0-beta.5"
 perseus-macro = { path = "../perseus-macro", version = "0.3.5" }
 # TODO review feature flags here
 web-sys = { version = "0.3", features = [ "Headers", "Navigator", "NodeList", "Request", "RequestInit", "RequestMode", "Response", "ReadableStream", "Window" ] }

--- a/packages/perseus/src/template/core.rs
+++ b/packages/perseus/src/template/core.rs
@@ -11,6 +11,7 @@ use crate::Request;
 use crate::SsrNode;
 use futures::Future;
 use http::header::HeaderMap;
+use sycamore::prelude::create_scope_immediate;
 use sycamore::prelude::{Scope, View};
 
 /// A generic error type that can be adapted for any errors the user may want to return from a render function. `.into()` can be used
@@ -205,15 +206,21 @@ impl<G: Html> Template<G> {
     /// Executes the user-given function that renders the document `<head>`, returning a string to be interpolated manually.
     /// Reactivity in this function will not take effect due to this string rendering. Note that this function will provide a translator context.
     pub fn render_head_str(&self, props: PageProps, translator: &Translator) -> String {
-        sycamore::render_to_string(|cx| {
+        let mut ret = None;
+        // TODO: This is a hack to prevent inserting hydration keys into the head.
+        // We render the template into a `View<SsrNode>` outside of the hydration context (created in `sycamore::render_to_string`).
+        create_scope_immediate(|cx| {
             // The context we have here has no context elements set on it, so we set all the defaults (job of the router component on the client-side)
             // We don't need the value, we just want the context instantiations
             let _ = RenderCtx::server(cx);
             // And now provide a translator separately
             provide_context_signal_replace(cx, translator.clone());
 
-            (self.head)(cx, props)
-        })
+            let view = (self.head)(cx, props);
+
+            ret = Some(sycamore::render_to_string(|_| view));
+        });
+        ret.unwrap()
     }
     /// Gets the list of templates that should be prerendered for at build-time.
     pub async fn get_build_paths(&self) -> Result<Vec<String>, ServerError> {

--- a/packages/perseus/src/template/core.rs
+++ b/packages/perseus/src/template/core.rs
@@ -202,8 +202,8 @@ impl<G: Html> Template<G> {
 
         (self.template)(cx, props)
     }
-    /// Executes the user-given function that renders the document `<head>`, returning a string to be interpolated manually. Reactivity
-    /// in this function will not take effect due to this string rendering. Note that this function will provide a translator context.
+    /// Executes the user-given function that renders the document `<head>`, returning a string to be interpolated manually.
+    /// Reactivity in this function will not take effect due to this string rendering. Note that this function will provide a translator context.
     pub fn render_head_str(&self, props: PageProps, translator: &Translator) -> String {
         sycamore::render_to_string(|cx| {
             // The context we have here has no context elements set on it, so we set all the defaults (job of the router component on the client-side)

--- a/packages/perseus/src/template/core.rs
+++ b/packages/perseus/src/template/core.rs
@@ -11,8 +11,7 @@ use crate::Request;
 use crate::SsrNode;
 use futures::Future;
 use http::header::HeaderMap;
-use sycamore::prelude::create_scope_immediate;
-use sycamore::prelude::{Scope, View};
+use sycamore::prelude::{create_scope_immediate, Scope, View};
 
 /// A generic error type that can be adapted for any errors the user may want to return from a render function. `.into()` can be used
 /// to convert most error types into this without further hassle. Otherwise, use `Box::new()` on the type.

--- a/packages/perseus/src/utils/context.rs
+++ b/packages/perseus/src/utils/context.rs
@@ -1,14 +1,6 @@
-use sycamore::prelude::{
-    create_signal, provide_context_ref, try_use_context, use_context, Scope, Signal,
-};
+use sycamore::prelude::{create_signal, provide_context_ref, try_use_context, Scope, Signal};
 
 /// Adds the given value to the given reactive scope inside a `Signal`, replacing a value of that type if one is already present. This returns a reference to the `Signal` inserted.
 pub(crate) fn provide_context_signal_replace<T: 'static>(cx: Scope, val: T) -> &Signal<T> {
-    if let Some(ctx) = try_use_context::<Signal<T>>(cx) {
-        ctx.set(val);
-    } else {
-        provide_context_ref(cx, create_signal(cx, val));
-    }
-
-    use_context(cx)
+    try_use_context(cx).unwrap_or_else(|| provide_context_ref(cx, create_signal(cx, val)))
 }

--- a/packages/perseus/src/utils/context.rs
+++ b/packages/perseus/src/utils/context.rs
@@ -1,6 +1,6 @@
-use sycamore::prelude::{create_signal, provide_context_ref, try_use_context, Scope, Signal};
+use sycamore::prelude::{create_signal, use_context_or_else_ref, Scope, Signal};
 
 /// Adds the given value to the given reactive scope inside a `Signal`, replacing a value of that type if one is already present. This returns a reference to the `Signal` inserted.
 pub(crate) fn provide_context_signal_replace<T: 'static>(cx: Scope, val: T) -> &Signal<T> {
-    try_use_context(cx).unwrap_or_else(|| provide_context_ref(cx, create_signal(cx, val)))
+    use_context_or_else_ref(cx, || create_signal(cx, val))
 }


### PR DESCRIPTION
TODO: this currently uses a hack that I'm not so proud of. I'll probably need to release a new version of sycamore to do this properly but at least the problem is fixed.

The problem with hydration was that hydration keys were rendered in the head strings. This would cause a conflict when hydrating because there would be multiple nodes with the same hydration keys. That, in turn, is because there are multiple calls to `render_to_string`, each which creates a new "hydration context".

Note that this is a PR against the `feat-sycamore-0.4.0` branch instead of the `main` branch.