### PR TITLE
Fix `server` binary name in pkg. (Windows)

### DIFF
--- a/packages/perseus-cli/src/deploy.rs
+++ b/packages/perseus-cli/src/deploy.rs
@@ -65,7 +65,11 @@ fn deploy_full(dir: PathBuf, output: String) -> Result<i32, Error> {
             .into());
         }
         // Copy in the server executable
+        #[cfg(target_os = "windows")]
+        let to = output_path.join("server.exe");
+        #[cfg(not(target_os = "windows"))]
         let to = output_path.join("server");
+        
         if let Err(err) = fs::copy(&server_path, &to) {
             return Err(DeployError::MoveAssetFailed {
                 to: to.to_str().map(|s| s.to_string()).unwrap(),


### PR DESCRIPTION
The current `deploy` commands for the CLI creates a pkg folder and copy the server binary with filename `server`, even on Windows. I still can change the binary name and add exe extension to it and it will run just fine.


This PR aims to fix the binary name for Windows to `server.exe`.