### PR TITLE
Update to actix-web 4.1.0

### DIFF
--- a/packages/perseus-actix-web/Cargo.toml
+++ b/packages/perseus-actix-web/Cargo.toml
@@ -15,10 +15,10 @@ categories = ["wasm", "web-programming::http-server", "development-tools", "asyn
 
 [dependencies]
 perseus = { path = "../perseus", version = "0.4.0-beta.5" }
-actix-web = "=4.0.0-rc.3"
-actix-http = "=3.0.0-rc.2" # Without this, Actix can introduce breaking changes in a dependency tree
+actix-web = "=4.1.0"
+actix-http = "=3.2.1" # Without this, Actix can introduce breaking changes in a dependency tree
 # actix-router = "=0.5.0-rc.3"
-actix-files = "=0.6.0-beta.16"
+actix-files = "=0.6.2"
 urlencoding = "2.1"
 serde = "1"
 serde_json = "1"


### PR DESCRIPTION
This PR aims to update the actix integration dependencies to the current stable release of actix-web.
Some other actix packages are also updated accordingly. I have checked that this build the default "Hello World" (with actix-web integration of course) example with no problem.

There is also another side project I'm working on which I also checked that works correctly with this updated version. Everything Just Works™.
